### PR TITLE
enable download as html

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Shiny user interface (UI) and MoveStack in Movebank format.
 ### Artefacts
 None.
 
-The `Save Plot` button enables a local download of the created plot.
+The `Save to Html` button enables a local download of the created plot as html.
 <!---
 `DensityMap.png`: The visualization produced by the App can be saved (via "Save Plot") in *.png* format to the "Output" folder in Moveapps.
 -->

--- a/ShinyModule.R
+++ b/ShinyModule.R
@@ -7,6 +7,7 @@ library(mapview)
 library(leaflet)
 library(leaflegend)
 library(shinycssloaders)
+library(htmlwidgets)
 library(webshot)
 # webshot::install_phantomjs() ## add in docker images in moveapps: R -e 'webshot::install_phantomjs()' 
 
@@ -39,7 +40,7 @@ shinyModuleUserInterface <- function(id, label) {
         
         mainPanel(withSpinner(leafletOutput(ns("leafmap"), height="82vh"),type=6, size=2),
                   #actionButton(ns('savePlot'), 'Save Plot'), #for artefact in output
-                  downloadButton(ns('savePlot'), 'Save Plot'), # for downloading map on local computer
+                  downloadButton(ns('savePlot'), 'Save as Html'), # for downloading map on local computer
                   width = 10)
       ), tags$head(tags$style(".myRow1{height:25px;background-color: white;}"))
     )
@@ -132,19 +133,21 @@ shinyModule <- function(input, output, session, data) {
   
   ### save map, takes some seconds ### here user can choose directory
   output$savePlot <- downloadHandler(
-    filename = function() {
-      paste("Leaflet_densityMap.png", sep="")
-    },
+    filename = "Leaflet_densityMap.html",
     content = function(file) {
-      leafmap <- rmap()
-      mapshot( x = leafmap
-               , remove_controls = c("zoomControl","layersControl")
-               , file = file
-               , cliprect = "viewport"
-               , selfcontained = FALSE
-               , zoom = 1.5
-               , vwidth = 992*2, vheight = 744*2 #default size * 1.1
-      ) 
+      saveWidget(
+        widget=rmap(),
+        file=file
+      )
+      #leafmap <- rmap()
+      #mapshot( x = leafmap
+      #         , remove_controls = c("zoomControl","layersControl")
+      #         , file = file
+      #         , cliprect = "viewport"
+      #         , selfcontained = FALSE
+      #         , zoom = 1.5
+      #         , vwidth = 992*2, vheight = 744*2 #default size * 1.1
+      #) 
     }
   )
   

--- a/appspec.json
+++ b/appspec.json
@@ -31,6 +31,9 @@
       },
 	        {
         "name": "webshot"
+      },
+	  {
+        "name": "htmlwidgets"
       }
     ]
   },


### PR DESCRIPTION
Hi Martina, the download button for this App (as well as the one in the leaflet App) didnt work any more on MoveApps. Not sure why, but I have found a way to make it work as downloading an html file. This, I find even better than png or pdf, hope you agree. The leaflet App works ok on the develop site of Moveapps, I will bring it to www. I have seen that in this App of yours, you use the same functions for download button. I have adapted them accordingly to what I have done for the leaflet app. Please check and if you find things work well merge and submit a new version to moveapps. Thansk!